### PR TITLE
Add initial cmake build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
-build-vinyl-music-Desktop_Qt_5_5_1_GCC_64bit-Debug
-vinyl-music/vinyl-music.pro.*
-build-liri-vinyl-Unnamed-Debug
-build-liri-vinyl-Desktop_Qt_5_5_1_GCC_64bit-Debug
-build-liri-vinyl-Desktop_Qt_5_5_1_GCC_64bit-Profile
-build-liri-vinyl-Desktop_Qt_5_5_1_GCC_64bit-Release
-<<<<<<< HEAD
-liri-vinyl.pro.user
-=======
-build-liri-vinyl-Desktop_Qt_5_5_1_MinGW_32bit-Release
->>>>>>> 865f67ba47e0f3bef63eb54e2385cb432c3e00dc
+build*
+*.pro.*
+*.kdev4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8)
+project(liri-vinyl)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
+
+find_package(Qt5 COMPONENTS Core Gui Sql Quick Qml Svg REQUIRED)
+find_package(Taglib REQUIRED)
+
+include_directories(${TAGLIB_INCLUDE_DIRS})
+
+add_subdirectory(src)
+

--- a/cmake/Modules/FindTaglib.cmake
+++ b/cmake/Modules/FindTaglib.cmake
@@ -1,0 +1,25 @@
+# Try to find Taglib
+# Once done this will define
+# TAGLIB_FOUND - System has taglib
+# TAGLIB_INCLUDE_DIRS - The taglib include directories
+# TAGLIB_LIBRARIES - The libraries needed to use taglib
+# TAGLIB_DEFINITIONS - Compiler switches required for using taglib
+
+find_package(PkgConfig)
+pkg_check_modules(PC_TAGLIB QUIET taglib)
+set(TAGLIB_DEFINITIONS ${PC_TAGLIB_CFLAGS_OTHER})
+
+find_path(TAGLIB_INCLUDE_DIR taglib.h
+          HINTS ${PC_TAGLIB_INCLUDEDIR} ${PC_TAGLIB_INCLUDE_DIRS})
+
+find_library(TAGLIB_LIBRARY NAMES tag
+             HINTS ${PC_TAGLIB_LIBDIR} ${PC_TAGLIB_LIBRARY_DIRS})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TAGLIB DEFAULT_MSG TAGLIB_LIBRARY TAGLIB_INCLUDE_DIR)
+
+mark_as_advanced(TAGLIB_INCLUDE_DIR TAGLIB_LIBRARY)
+
+set(TAGLIB_LIBRARIES ${TAGLIB_LIBRARY})
+set(TAGLIB_INCLUDE_DIRS ${TAGLIB_INCLUDE_DIR})
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+
+set(liri_vinyl_SOURCES
+  main.cpp
+  utilities.cpp
+  songobject.cpp
+  albumobject.cpp
+  artistobject.cpp
+  musicfolders.cpp
+)
+
+qt5_add_resources(liri_vinyl_RESOURCES qml.qrc)
+
+add_executable(${CMAKE_PROJECT_NAME} ${liri_vinyl_SOURCES} ${liri_vinyl_RESOURCES})
+target_link_libraries(${CMAKE_PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Svg Qt5::Qml Qt5::Quick Qt5::Sql ${TAGLIB_LIBRARIES})
+

--- a/src/albumobject.cpp
+++ b/src/albumobject.cpp
@@ -1,0 +1,3 @@
+#include "albumobject.h"
+#include "moc_albumobject.cpp"
+

--- a/src/albumobject.h
+++ b/src/albumobject.h
@@ -6,7 +6,7 @@
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlQuery>
 #include <QList>
-#include <main.h>
+#include "songobject.h"
 #include <QVariant>
 #include <iostream>
 

--- a/src/artistobject.cpp
+++ b/src/artistobject.cpp
@@ -1,0 +1,2 @@
+#include "artistobject.h"
+#include "moc_artistobject.cpp"

--- a/src/artistobject.h
+++ b/src/artistobject.h
@@ -6,7 +6,7 @@
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlQuery>
 #include <QList>
-#include <main.h>
+#include "songobject.h"
 #include <QVariant>
 
 class ArtistObject : public QObject {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,13 +23,13 @@
 #include <QtSql/QSqlQuery>
 #include <QList>
 #include <QObject>
-#include <albumobject.h>
-#include <artistobject.h>
+#include "albumobject.h"
+#include "artistobject.h"
 #include <QStandardPaths>
-#include <main.h>
+#include "songobject.h"
 #include <unistd.h>
-#include <musicfolders.h>
-#include <utilities.h>
+#include "musicfolders.h"
+#include "utilities.h"
 
 
 

--- a/src/musicfolders.cpp
+++ b/src/musicfolders.cpp
@@ -1,0 +1,3 @@
+#include "musicfolders.h"
+#include "moc_musicfolders.cpp"
+

--- a/src/musicfolders.h
+++ b/src/musicfolders.h
@@ -6,7 +6,7 @@
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlQuery>
 #include <QList>
-#include <main.h>
+#include "songobject.h"
 #include <QVariant>
 #include <iostream>
 #include <taglib/taglib.h>
@@ -23,8 +23,8 @@
 #include <QDir>
 #include <stdlib.h>
 #include <sstream>
-#include <utilities.h>
-#include <albumobject.h>
+#include "utilities.h"
+#include "albumobject.h"
 
 class MusicFolders : public QObject {
     Q_OBJECT

--- a/src/songobject.cpp
+++ b/src/songobject.cpp
@@ -1,0 +1,4 @@
+#include "songobject.h"
+#include "moc_songobject.cpp"
+
+

--- a/src/songobject.h
+++ b/src/songobject.h
@@ -3,7 +3,6 @@
 
 #include <QObject>
 
-
 class SongObject : public QObject
 {
     Q_OBJECT

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -7,7 +7,7 @@
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlQuery>
 #include <QList>
-#include <main.h>
+#include "songobject.h"
 #include <QVariant>
 #include <iostream>
 #include <taglib/taglib.h>
@@ -21,7 +21,7 @@
 #include <QDateTime>
 #include <QQmlContext>
 #include <QFileInfo>
-#include <musicfolders.h>
+#include "musicfolders.h"
 
 Utilities::Utilities(QObject *parent)
 {

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -11,7 +11,7 @@
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlQuery>
 #include <QList>
-#include <main.h>
+#include "songobject.h"
 #include <QVariant>
 #include <iostream>
 #include <taglib/taglib.h>


### PR DESCRIPTION
As part of the creating the cmake build, some files were violating the
C++ One Definition rule, apparently this wasn't happening with the qmake
based build.

Also, main.h got renamed to songobject.h as the new name is more
descriptive.
