### PR TITLE
Make sure we aren't exiting the app too early.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,11 +70,14 @@ int main(int argc, char *argv[]){
     QThread t;
     scanner.moveToThread(&t);
     QObject::connect(&t, &QThread::started, &scanner, &MusicScanner::startScan);
+    QObject::connect(qApp, &QCoreApplication::aboutToQuit, &scanner, &MusicScanner::stop);
     t.start();
 
     engine.load(QUrl(QStringLiteral("qrc:/qml/main.qml")));
 
-    return app.exec();
+    int retval = app.exec();
+    t.wait();
+    return retval;
 }
 
 

--- a/src/musicscanner.cpp
+++ b/src/musicscanner.cpp
@@ -6,6 +6,7 @@
 #include <QList>
 #include <QGst/Caps>
 #include <QGst/Discoverer>
+#include <QThread>
 #include <iostream>
 
 MusicScanner::MusicScanner():
@@ -47,3 +48,8 @@ void MusicScanner::scan(const QDir& dir, QGst::DiscovererPtr& discoverer) {
         }
     }
 }
+
+void MusicScanner::stop() {
+  this->thread()->quit();
+}
+

--- a/src/musicscanner.h
+++ b/src/musicscanner.h
@@ -18,6 +18,7 @@ public:
 public slots:
     void startScan();
     void directoryChanged(const QString &path);
+    void stop();
 
 signals:
     void foundSong(const SongObject&);


### PR DESCRIPTION
We need to make sure we aren't exiting the application before all the
spawned threads and their corresponding event loops are shut down.
