### PR TITLE
Fixed crash when artist and album aren't set in tags

### DIFF
--- a/src/musicscanner.cpp
+++ b/src/musicscanner.cpp
@@ -60,7 +60,14 @@ void MusicScanner::scan(const QDir& dir, QGst::DiscovererPtr& discoverer) {
                 else
                   artist = Artist { 0, "Unknown Artist" };
 
-                Song song { 0, info->uri().toLocalFile(), info->tags().title(), 0, 0, "placeholder" };
+                Song song;
+                if(!info->tags().title().isEmpty())
+                  song = Song { 0, info->uri().toLocalFile(), info->tags().title(), 0, 0, "placeholder" };
+                else {
+                  QString path = MusicDatabase::get().getMusicFolder();
+                  QString title = info->uri().toLocalFile().right(info->uri().toLocalFile().size() - path.size());
+                  song = Song { 0, info->uri().toLocalFile(), title, 0, 0, "placeholder" };
+                }
 
                 Album album;
 

--- a/src/musicscanner.cpp
+++ b/src/musicscanner.cpp
@@ -53,9 +53,22 @@ void MusicScanner::scan(const QDir& dir, QGst::DiscovererPtr& discoverer) {
             }
 
             if(info->audioStreams().count() != 0){
-                Artist artist { 0, info->tags().artist() };
+
+                Artist artist;
+                if(!info->tags().artist().isEmpty())
+                  artist = Artist { 0, info->tags().artist() };
+                else
+                  artist = Artist { 0, "Unknown Artist" };
+
                 Song song { 0, info->uri().toLocalFile(), info->tags().title(), 0, 0, "placeholder" };
-                Album album { 0, info->tags().tagValue("album").toString(), 0, "placeholder" };
+
+                Album album;
+
+                if(!info->tags().tagValue("album").toString().isEmpty())
+                  album = Album { 0, info->tags().tagValue("album").toString(), 0, "placeholder" };
+                else
+                  album = Album { 0, "Unknown Album", 0, "placeholder" };
+
                 //emit foundSong(song);
                 //emit foundAlbum(album);
 

--- a/src/musicscanner.cpp
+++ b/src/musicscanner.cpp
@@ -65,7 +65,7 @@ void MusicScanner::scan(const QDir& dir, QGst::DiscovererPtr& discoverer) {
                   song = Song { 0, info->uri().toLocalFile(), info->tags().title(), 0, 0, "placeholder" };
                 else {
                   QString path = MusicDatabase::get().getMusicFolder();
-                  QString title = info->uri().toLocalFile().right(info->uri().toLocalFile().size() - path.size());
+                  QString title = info->uri().toLocalFile().right(info->uri().toLocalFile().size() - path.size() - 1);
                   song = Song { 0, info->uri().toLocalFile(), title, 0, 0, "placeholder" };
                 }
 


### PR DESCRIPTION
When the artist and album fields in the music file tags are empty, the application crashes. This should fix that by setting the artist and album title to "Unknown Artist" and "Unknown Title" respectively.
